### PR TITLE
Replace `find` command

### DIFF
--- a/build/package-generators/curlconverter.js
+++ b/build/package-generators/curlconverter.js
@@ -7,6 +7,7 @@ const path = require('path')
 const buildDir = execEnv.buildDir
 const packageJsonPath = path.join(buildDir, 'package.json')
 const packageLockPath = path.join(buildDir, 'package-lock.json')
+const generatorsDir = path.join(buildDir, 'src', 'generators')
 
 const projectDir = process.env.PROJECT_CWD
 const tarballPath = path.join(
@@ -51,11 +52,11 @@ child_process.execFileSync(
 fs.cpSync(packageLockSourcePath, packageLockPath)
 
 // Remove all generators except json
-child_process.execFileSync(
-  'find',
-  ['-not', '-name', 'json.ts', '-path', './src/generators/*', '-delete'],
-  { cwd: buildDir },
-)
+for (const file of fs.readdirSync(generatorsDir)) {
+  if (file !== 'json.ts') {
+    fs.rmSync(path.join(generatorsDir, file), { recursive: true, force: true })
+  }
+}
 fs.writeFileSync(
   path.join(buildDir, 'src/index.ts'),
   'export { toJsonString } from "./generators/json.js";',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,7 +1693,7 @@ __metadata:
 
 "curlconverter@exec:build/package-generators/curlconverter.js::locator=HackBar%40workspace%3A.":
   version: 4.11.0
-  resolution: "curlconverter@exec:build/package-generators/curlconverter.js#build/package-generators/curlconverter.js::hash=513541&locator=HackBar%40workspace%3A."
+  resolution: "curlconverter@exec:build/package-generators/curlconverter.js#build/package-generators/curlconverter.js::hash=982dc7&locator=HackBar%40workspace%3A."
   dependencies:
     jsesc: "npm:^3.0.2"
     lossless-json: "npm:^4.0.2"
@@ -1702,7 +1702,7 @@ __metadata:
     tree-sitter-bash: "npm:^0.23.1"
     web-tree-sitter: "npm:^0.24.3"
     yamljs: "npm:^0.3.0"
-  checksum: 10c0/92243714b9377c725b48a64f5e4d63f5f37e68b67ab38677bb72a57607d5ff36d47a0ffe462a4e4b399faa902e0e807e996d92e59f9e334de717fbbc805be69d
+  checksum: 10c0/a63e24fff5da2d3ad756d886d63d8ee0107f1dd49c4be83ef7506bac38bb63084ddc86d4dccb6514c479e3aea2daf8de1535a5c42af8806d64f2ca90ecf34fbe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use `fs.readdirSync` and `fs.rmSync` instead of `child_process.execFileSync` with `find` command for better maintainability and cross-platform compatibility.

With this change, `curlconverter.js` can be run on Mac.